### PR TITLE
feat: add apilocate and openWeather api services and test route current

### DIFF
--- a/controllers/handlers/v1/weather.js
+++ b/controllers/handlers/v1/weather.js
@@ -1,5 +1,17 @@
+const { getLocate } = require('../../../services/ipLocate');
+const { getCurrent, getForecast, getDirectGeoCoding } = require('../../../services/apiOpenWeather');
+
 const currentHandler = async (request, reply) => {
-  reply.code(200).send({ status: 'ok' });
+  let response = {};
+  if(request.params['city']){
+     const {name, lat, lon} = await getDirectGeoCoding(request.params['city']);
+    response = await getForecast(lat, lon);
+    response.city = name;
+  }else{
+    
+  }
+
+  return reply.code(200).send(response);
 };
 
 module.exports = { currentHandler };

--- a/controllers/schemas/v1/weather.js
+++ b/controllers/schemas/v1/weather.js
@@ -1,12 +1,33 @@
+const dailySchema = {
+  dt: { type: 'number' },
+  sunrise: { type: 'number' },
+  sunset: { type: 'number' },
+  moonrise: { type: 'number' },
+  moonset: { type: 'number' },
+  moon_phase: { type: 'number' },
+  temp: { type: 'object' },
+  feels_like: { type: 'object' },
+  pressure: { type: 'number' },
+  humidity: { type: 'number' },
+  dew_point: { type: 'number' },
+  wind_speed: { type: 'number' },
+  wind_deg: { type: 'number' },
+  wind_gust: { type: 'number' },
+  weather: { type: 'array' },
+  clouds: { type: 'number' },
+  pop: { type: 'number' },
+  uvi: { type: 'number' }
+};
+
 const currentSchema = {
-  querystring: {
-    name: { type: 'string' }
-  },
   response: {
     200: {
       type: 'object',
       properties: {
-        status: { type: 'string' }
+        city: { type: 'string' },
+        timezone: { type: 'string' },
+        current: dailySchema,
+        daily: dailySchema
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
   },
   "dependencies": {
     "@fastify/autoload": "^4.0.1",
+    "@supercharge/request-ip": "^1.2.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.0.0",
     "fastify": "^3.29.0",
     "fastify-cli": "^2.15.0",
-    "fastify-plugin": "^3.0.1"
+    "fastify-plugin": "^3.0.1",
+    "node-fetch": "^2.6.7",
+    "node-iplocate": "^1.0.3"
   },
   "eslintConfig": {
     "env": {

--- a/routes/v1/weather.js
+++ b/routes/v1/weather.js
@@ -12,7 +12,7 @@ module.exports = (fastify, options, done) => {
     reply.code(201).send({ status: 'V1 running OK' });
   });
 
-  fastify.get('/current', currentOpts);
+  fastify.get('/current/:city?', currentOpts);
 
 
   done();

--- a/services/apiOpenWeather.js
+++ b/services/apiOpenWeather.js
@@ -1,0 +1,37 @@
+const fetch = require('node-fetch');
+const { OPENWEATHER_KEY: apiKey } = process.env;
+
+const baseUrl = 'https://api.openweathermap.org/data/2.5/';
+const geoUrl = 'http://api.openweathermap.org/geo/1.0/';
+
+const getForecast = async (lat, lon) => {
+  const response = await fetch(`${baseUrl}onecall?lat=${lat}&lon=${lon}&exclude=minutely,hourly&units=metric&appid=${apiKey}`);
+  const data = await response.json();
+
+  return data;
+};
+
+const getCurrent = async (lat, lon) => {
+  const response = await fetch(`${baseUrl}onecall?lat=${lat}&lon=${lon}&units=metric&appid=${apiKey}`);
+  const data = response.json();
+  return data;
+};
+
+const getDirectGeoCoding = async (city) => {
+  const cityEncoded = encodeURIComponent(city);
+  const limit = 1;
+  const response = await fetch(`${geoUrl}direct?q=${cityEncoded}&limit=${limit}&appid=${apiKey}`);
+  const data = await response.json();
+
+  return data[0];
+};
+
+const getReverseGeoCoding = async (lat, lon) => {
+  const limit = 1;
+  const response = await fetch(`${geoUrl}direct?reverse?lat=${lat}&lon=${lon}&limit=${limit}&appid=${apiKey}`);
+  const data = response.json();
+
+  return data[0];
+};
+
+module.exports = { getForecast, getCurrent, getDirectGeoCoding, getReverseGeoCoding };

--- a/services/ipLocate.js
+++ b/services/ipLocate.js
@@ -1,0 +1,14 @@
+
+const iplocate = require('node-iplocate');
+const requestIp = require('@supercharge/request-ip');
+const { NODE_ENV, DEV_IP } = process.env;
+
+const getLocate = async (req) => {
+  const clientIp = NODE_ENV !== 'DEV' ? requestIp.getClientIp(req) : DEV_IP;
+  const location = await iplocate(clientIp);
+
+  return location;
+};
+
+
+module.exports = { getLocate };


### PR DESCRIPTION
Se agregaron servicios para obtener la ip del cliente y para obtener el clima.
Se agrego la ruta /current/:city? para poder testear el funcionamiento de los servicios